### PR TITLE
fix: unify header/footer colors with shared config

### DIFF
--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Archive</title>
+    <script src="/template.v2.js"></script>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+
+      body {
+        margin: 0;
+        background-color: hsl(200, 60%, 15%);
+        /* Note: This color should match THEME.primaryColor in config.ts */
+      }
+
+      d-article {
+        display: block;
+        background: white;
+        color: rgba(0, 0, 0, 0.8);
+        padding-bottom: 72px;
+      }
+
+      d-article.centered > h1 {
+        margin: 72px 24px 12px;
+        font-weight: 400;
+        font-family: Cochin, Georgia, serif;
+        font-size: 46px;
+        line-height: 1.1;
+        letter-spacing: -0.02em;
+      }
+
+      @media (min-width: 768px) {
+        d-article.centered > h1 {
+          margin: 96px 72px 24px;
+          font-size: 54px;
+        }
+      }
+
+      @media (min-width: 1080px) {
+        d-article.centered > h1 {
+          margin-left: auto;
+          margin-right: auto;
+          text-align: center;
+        }
+      }
+
+      .issues {
+        margin: 0 24px 48px;
+      }
+
+      @media (min-width: 768px) {
+        .issues {
+          margin-left: 72px;
+          margin-right: 72px;
+        }
+      }
+
+      @media (min-width: 1080px) {
+        .issues {
+          margin-left: auto;
+          margin-right: auto;
+          max-width: 648px;
+        }
+      }
+
+      .issues ul {
+        margin-top: 12px;
+        padding: 0;
+        list-style: none;
+      }
+
+      .issues li {
+        margin-bottom: 16px;
+      }
+
+      .issues li a {
+        border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+        text-decoration: none;
+      }
+
+      .issues li a:hover {
+        border-bottom-color: rgba(0, 0, 0, 0.4);
+      }
+
+      .issues li div,
+      .issues li .doi {
+        font-family: -apple-system, BlinkMacSystemFont, "Roboto", Helvetica, sans-serif;
+        color: grey;
+        font-size: 13px;
+        line-height: 20px;
+      }
+
+      .empty {
+        margin: 48px 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Roboto", Helvetica, sans-serif;
+        color: rgba(0, 0, 0, 0.6);
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <distill-header></distill-header>
+    <d-article class="centered">
+      <h1>Distill Archive</h1>
+      <div class="issues">
+        
+        <ul>
+          <li><a href="/index.html">Why Momentum Really Works</a><div data-published-date="2017-01-10T00:00:00.000Z">Jan 10, 2017</div><div>Chris Olah, Ludwig Schubert, Shan Carter</div></li>
+        </ul>
+      
+      </div>
+    </d-article>
+    <distill-footer></distill-footer>
+  </body>
+</html>

--- a/src/distill-components/config.ts
+++ b/src/distill-components/config.ts
@@ -1,0 +1,4 @@
+// Shared configuration for distill components
+export const THEME = {
+  primaryColor: 'hsl(200, 60%, 15%)',
+}

--- a/src/distill-components/distill-footer-template.ts
+++ b/src/distill-components/distill-footer-template.ts
@@ -1,4 +1,5 @@
 import logo from '../assets/distill-logo.svg?raw'
+import { THEME } from './config'
 
 export const footerTemplate = `
 <style>
@@ -8,7 +9,7 @@ export const footerTemplate = `
   font-weight: 300;
   padding: 2rem 0;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
-  background-color: hsl(180, 5%, 15%); /*hsl(200, 60%, 15%);*/
+  background-color: ${THEME.primaryColor};
   text-align: left;
   contain: content;
 }
@@ -59,12 +60,9 @@ export const footerTemplate = `
   </a> is dedicated to clear explanations of machine learning
 
   <div class="nav">
-    <a href="/about/">About</a>
-    <a href="/archive/">Archive</a>
-    <a href="/rss">RSS</a>
+    <a href="https://github.com/seonglae/post-template/pull/new/master">Submit</a>
     <a href="https://github.com/seonglae/post-template">GitHub</a>
     <a href="https://twitter.com/SeonglaeC">Twitter</a>
-    &nbsp;&nbsp;&nbsp;&nbsp; ISSN 2476-0757
   </div>
 
 </div>

--- a/src/distill-components/distill-header-template.ts
+++ b/src/distill-components/distill-header-template.ts
@@ -1,11 +1,12 @@
 import logo from '../assets/distill-logo.svg?raw'
+import { THEME } from './config'
 
 export const headerTemplate = `
 <style>
 distill-header {
   position: relative;
   height: 60px;
-  background-color: hsl(200, 60%, 15%);
+  background-color: ${THEME.primaryColor};
   width: 100%;
   box-sizing: border-box;
   z-index: 2;
@@ -71,7 +72,7 @@ distill-header .nav a {
     Distill
   </a>
   <nav class="nav">
-    <a href="/about/">About</a>
+    <a href="https://github.com/seonglae/post-template/pull/new/master">Submit</a>
   </nav>
 </div>
 `


### PR DESCRIPTION
## Summary
- Extract shared THEME config to `config.ts` for consistent header/footer styling
- Update header and footer to use `THEME.primaryColor` instead of hardcoded values
- Change nav links to "Submit" pointing to GitHub PR creation page

## Test plan
- [ ] Verify header and footer have matching colors
- [ ] Click Submit link and confirm it goes to PR creation page
- [ ] Run `pnpm build` and `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)